### PR TITLE
Call for annotation specifying isoform

### DIFF
--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/BatchConfiguration.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/BatchConfiguration.java
@@ -90,6 +90,7 @@ public class BatchConfiguration
     }
 
     @Bean
+    @StepScope
     public MutationRecordProcessor processor()
     {
         return new MutationRecordProcessor();

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationFieldSetMapper.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationFieldSetMapper.java
@@ -32,7 +32,7 @@
 
 package org.cbioportal.annotation.pipeline;
 
-import java.util.List;
+import java.util.*;
 import org.cbioportal.models.MutationRecord;
 import org.springframework.batch.item.file.mapping.FieldSetMapper;
 import org.springframework.batch.item.file.transform.FieldSet;
@@ -47,17 +47,17 @@ public class MutationFieldSetMapper implements  FieldSetMapper<MutationRecord> {
     @Override
     public MutationRecord mapFieldSet(FieldSet fs) throws BindException {
         MutationRecord record = new MutationRecord();
-        List<String> fields = record.getHeader();
+        Set<String> names = new HashSet(Arrays.asList(fs.getNames()));
+        names.addAll(record.getHeader());
         
-        for (int i = 0; i < fs.getFieldCount(); i++)
+        for (String field : names)
         {            
             try {
-                String field = fields.get(i);
-                record.getClass().getMethod("set" + field, String.class).invoke(record, fs.readString(i));                
+                record.getClass().getMethod("set" + field, String.class).invoke(record, fs.readRawString(field));                
             }
             catch(Exception e) {
                 if (e.getClass().equals(NoSuchMethodException.class) || e.getClass().equals(IndexOutOfBoundsException.class)) {
-                    record.addAdditionalProperty(fs.getNames()[i], fs.readString(i));
+                    record.addAdditionalProperty(field, fs.readRawString(field));
                 }                
             }
          }       

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordProcessor.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordProcessor.java
@@ -34,16 +34,21 @@ package org.cbioportal.annotation.pipeline;
 
 import org.cbioportal.models.AnnotatedRecord;
 import org.springframework.batch.item.ItemProcessor;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  *
  * @author Zachary Heins
  */
 public class MutationRecordProcessor implements ItemProcessor<AnnotatedRecord, String>{
-     @Override
+    @Value("#{stepExecutionContext['mutation_header']}")
+    private List<String> header;
+    
+    @Override
     public String process(AnnotatedRecord i) throws Exception {
         String to_write = "";
-        for (String field : i.getHeaderWithAdditionalFields()) {
+        for (String field : header) {
             try {
                 to_write += i.getClass().getMethod("get" + field).invoke(i) + "\t";
             }

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
@@ -59,6 +59,7 @@ public class MutationRecordReader  implements ItemStreamReader<AnnotatedRecord>{
     
     private List<MutationRecord> mutationRecords = new ArrayList<>();
     private List<AnnotatedRecord> annotatedRecords = new ArrayList<>();
+    private Set<String> header = new LinkedHashSet<>();
     
     @Autowired
     Annotator annotator;
@@ -99,7 +100,10 @@ public class MutationRecordReader  implements ItemStreamReader<AnnotatedRecord>{
         
         for(MutationRecord record : mutationRecords) {
             annotatedRecords.add(annotator.annotateRecord(record, replace.equals("true"), isoformOverride, true));
+            header.addAll(record.getHeaderWithAdditionalFields());
         }
+        List<String> full_header = new ArrayList(header);
+        ec.put("mutation_header", full_header);
     }
 
     @Override

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordWriter.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordWriter.java
@@ -55,6 +55,9 @@ public class MutationRecordWriter implements ItemStreamWriter<String> {
     @Value("#{stepExecutionContext['commentLines']}")
     private List<String> commentLines;   
     
+    @Value("#{stepExecutionContext['mutation_header']}")
+    private List<String> header;
+    
     private Path stagingFile;
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
 
@@ -75,7 +78,7 @@ public class MutationRecordWriter implements ItemStreamWriter<String> {
                 for (String comment : commentLines) {
                     writer.write(comment + "\n");
                 }
-                writer.write(StringUtils.join(record.getHeaderWithAdditionalFields(), "\t"));
+                writer.write(StringUtils.join(header, "\t"));
             }                
         });  
         flatFileItemWriter.open(ec);        

--- a/annotationPipeline/src/main/resources/application-test.properties.EXAMPLE
+++ b/annotationPipeline/src/main/resources/application-test.properties.EXAMPLE
@@ -1,0 +1,10 @@
+spring.batch.job.enabled=false
+genomenexus.hgvs=<HOST>/variant_annotation/hgvs/
+genomenexus.isoform_override=<HOST>/variant_annotation/isoform_override/
+genomenexus.hotspot_parameter=summary
+chunk=10
+
+
+input.inputfile=genome-nexus-annotation-pipeline/annotationPipeline/src/main/resources/data/testmaf.txt
+input.expectedfile=genome-nexus-annotation-pipeline/annotationPipeline/src/main/resources/data/expectedmaf.txt
+input.outputfile=genome-nexus-annotation-pipeline/annotationPipeline/target/test-outputs/output.txt

--- a/annotationPipeline/src/main/resources/application.properties.EXAMPLE
+++ b/annotationPipeline/src/main/resources/application.properties.EXAMPLE
@@ -1,4 +1,5 @@
 spring.batch.job.enabled=false
 genomenexus.hgvs=<HOST>/variant_annotation/hgvs/
-genomenexus.isoform_override=<HOST>/variant_annotation/isoform_override/
+genomenexus.isoform_query_parameter=isoformOverrideSource
+genomenexus.hotspot_parameter=summary
 chunk=10

--- a/annotator/src/main/java/org/cbioportal/models/AnnotatedRecord.java
+++ b/annotator/src/main/java/org/cbioportal/models/AnnotatedRecord.java
@@ -47,6 +47,7 @@ public class AnnotatedRecord extends MutationRecord{
     protected String proteinPosStart;
     protected String proteinPosEnd;
     protected String codonChange;
+    protected String hotspot;
     
     static {                       
         HEADER.add("HGVSc");
@@ -56,6 +57,7 @@ public class AnnotatedRecord extends MutationRecord{
         HEADER.add("RefSeq");
         HEADER.add("Protein_position");
         HEADER.add("Codons");        
+        HEADER.add("Hotspot");
     }       
 
     public AnnotatedRecord() {}
@@ -106,6 +108,7 @@ public class AnnotatedRecord extends MutationRecord{
         String proteinPosStart,
         String proteinPosEnd,
         String codonChange,
+        String hotspot,
         Map<String, String> additionalProperties
     ) {        
         super(hugoSymbol,
@@ -155,6 +158,7 @@ public class AnnotatedRecord extends MutationRecord{
         this.proteinPosStart = proteinPosStart;
         this.proteinPosEnd = proteinPosEnd;
         this.codonChange = codonChange;
+        this.hotspot = hotspot;
     }  
 
     public String getHGVSc() {
@@ -211,5 +215,13 @@ public class AnnotatedRecord extends MutationRecord{
     
     public void setCodons(String codonChange) {
         this.codonChange = codonChange;
-    }        
+    }
+    
+    public String getHotspot() {
+        return this.hotspot;
+    }
+    
+    public void setHotspot(String hotspot) {
+        this.hotspot = hotspot;
+    }      
 }

--- a/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
+++ b/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
@@ -185,7 +185,7 @@ public class MutationRecord {
     }
     
     public String getEntrez_Gene_Id() {
-        return this.endPosition == null ? "" : this.entrezGeneId;
+        return this.entrezGeneId == null ? "" : this.entrezGeneId;
     }
 
     public void setEntrez_Gene_Id(String entrezGeneId) {

--- a/annotator/src/main/java/org/cbioportal/models/TranscriptConsequence.java
+++ b/annotator/src/main/java/org/cbioportal/models/TranscriptConsequence.java
@@ -59,7 +59,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "hgvsp",
     "protein_end",
     "protein_start",
-    "refseq_transcript_ids"
+    "refseq_transcript_ids",
+    "isHotspot"
 })
 public class TranscriptConsequence {
 
@@ -93,6 +94,8 @@ public class TranscriptConsequence {
     private String proteinStart;
     @JsonProperty("refseq_transcript_ids")
     private List<String> refseqTranscriptIds = new ArrayList<String>();
+    @JsonProperty("isHotspot")
+    private String isHotspot;    
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
@@ -119,8 +122,9 @@ public class TranscriptConsequence {
     * @param proteinEnd
     * @param hgncId
     * @param canonical
+    * @param isHotspot
     */
-    public TranscriptConsequence(List<String> consequenceTerms, String geneId, String geneSymbol, String hgncId, String proteinId, String transcriptId, String variantAllele, String aminoAcids, String canonical, String codons, String hgvsc, String hgvsp, String proteinEnd, String proteinStart, List<String> refseqTranscriptIds) {
+    public TranscriptConsequence(List<String> consequenceTerms, String geneId, String geneSymbol, String hgncId, String proteinId, String transcriptId, String variantAllele, String aminoAcids, String canonical, String codons, String hgvsc, String hgvsp, String proteinEnd, String proteinStart, List<String> refseqTranscriptIds, String isHotspot) {
         this.consequenceTerms = consequenceTerms;
         this.geneId = geneId;
         this.geneSymbol = geneSymbol;
@@ -136,6 +140,7 @@ public class TranscriptConsequence {
         this.proteinEnd = proteinEnd;
         this.proteinStart = proteinStart;
         this.refseqTranscriptIds = refseqTranscriptIds;
+        this.isHotspot = isHotspot;
     }
 
     /**
@@ -305,7 +310,7 @@ public class TranscriptConsequence {
     */
     @JsonProperty("canonical")
     public String getCanonical() {
-        return canonical;
+        return canonical != null ? canonical : "0";
     }
 
     /**
@@ -437,6 +442,26 @@ public class TranscriptConsequence {
     public void setRefseqTranscriptIds(List<String> refseqTranscriptIds) {
         this.refseqTranscriptIds = refseqTranscriptIds;
     }
+    
+    /**
+    * 
+    * @return
+    * The isHotspot
+    */
+    @JsonProperty("isHotspot")
+    public String getIsHotspot() {
+        return isHotspot;
+    }
+
+    /**
+    * 
+    * @param isHotspot
+    * The isHotspot
+    */
+    @JsonProperty("isHotspot")
+    public void setIsHotspot(String isHotspot) {
+        this.isHotspot = isHotspot;
+    }    
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {


### PR DESCRIPTION
Simplifies the logic for selecting the "canonical" transcript by specifying it in the annotation call to genome-nexus. Also improves performance by not making two calls per variant.

Reviewers:
@n1zea144, Onur