### PR TITLE
Added logic for handling inframe_insertion canonical transcripts

### DIFF
--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordProcessor.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordProcessor.java
@@ -32,9 +32,11 @@
 
 package org.cbioportal.annotation.pipeline;
 
+import java.util.ArrayList;
 import org.cbioportal.models.AnnotatedRecord;
 import org.springframework.batch.item.ItemProcessor;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 
 /**
@@ -47,15 +49,15 @@ public class MutationRecordProcessor implements ItemProcessor<AnnotatedRecord, S
     
     @Override
     public String process(AnnotatedRecord i) throws Exception {
-        String to_write = "";
+        List<String> record = new ArrayList();
         for (String field : header) {
             try {
-                to_write += i.getClass().getMethod("get" + field).invoke(i) + "\t";
+                record.add(i.getClass().getMethod("get" + field).invoke(i).toString());
             }
             catch (Exception e) {
-                to_write += i.getAdditionalProperties().get(field) + "\t";
+                record.add(i.getAdditionalProperties().getOrDefault(field,""));
             }
         }        
-        return to_write.substring(0, to_write.length());
+        return StringUtils.join(record, "\t");
     }   
 }


### PR DESCRIPTION
1. Added logic for handling inframe_insertion and deletion canonical transcripts
Some inframe_insertion cases were being missed by genome nexus when resolving protein change.

2. Added code to correctly resolve genome assembly name and variant classification
If genome nexus could not resolve a variant then these fields would be left empty instead of retaining what was in the input MAF file

3. Fixed how `MutationRecordProcessor` generates a line record to pass to the `MutationRecordWriter`
Extra tabs were being inserted at the end of the line, creating one extra field in the row relative to the MAF header

4. Added logging to `MutationRecordReader` to alert whether a variant could not be annotated

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>