### PR TITLE
Genome Nexus pipeline enhancements

### DIFF
--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
@@ -77,7 +77,7 @@ public class AnnotationPipeline
         JobParameters jobParameters = new JobParametersBuilder()
             .addString("filename", filename)
             .addString("outputFilename", outputFilename)
-            .addString("replace", replace == true ? "true" : "false")
+            .addString("replace", String.valueOf(replace))
             .addString("isoformOverride", isoformOverride)
     		.toJobParameters();  
         JobExecution jobExecution = jobLauncher.run(annotationJob, jobParameters);

--- a/annotator/src/main/java/org/cbioportal/annotator/Annotator.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/Annotator.java
@@ -42,6 +42,7 @@ import java.util.Map;
 public interface Annotator {
      
     AnnotatedRecord annotateRecord(MutationRecord record, boolean replaceHugo, String isoformOverride, boolean reannotate);
-    MutationRecord createRecord(Map<String, String> mafLine) throws Exception; 
+    MutationRecord createRecord(Map<String, String> mafLine) throws Exception;
+    boolean isHgvspNullClassifications(String variantClassification);
     
 }

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -766,6 +766,11 @@ public class GenomeNexusImpl implements Annotator {
             return tumorSeqAllele = record.getTumor_Seq_Allele1();
         }
     }
+    
+    @Override
+    public boolean isHgvspNullClassifications(String variantClassification) {
+        return hgvspNullClassifications.contains(variantClassification);
+    }
 
     public static void main(String[] args) {}
 }


### PR DESCRIPTION
Added some more detailed logging when a record fails to annotate
* this helps indicate whether a variant failed to annotate because there's something wrong with the data itself or if it failed to annotate because it's a non-coding region, mitochondrial variant, etc.

Added logging to reader that summarizes total records that failed to annotate 
* also includes breakdown of how many variants failed to annotate because of HGVSp null variant classifications or because they are mitochondrial variants

Standardized job parameters configuration for `replace` parameter

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>