### PR TITLE
Do not use static header in mut record

### DIFF
--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -238,7 +238,7 @@ public class GenomeNexusImpl implements Annotator {
     @Override
     public MutationRecord createRecord(Map<String, String> mafLine) throws Exception {
         MutationRecord record = new MutationRecord();
-        for (String header : new MutationRecord().getHeader()) {
+        for (String header : record.getHeader()) {
             if(mafLine.keySet().contains(header)) {
                 record.getClass().getMethod("set" + header, String.class).invoke(record, mafLine.remove(header));
             }

--- a/annotator/src/main/java/org/cbioportal/models/AnnotatedRecord.java
+++ b/annotator/src/main/java/org/cbioportal/models/AnnotatedRecord.java
@@ -49,21 +49,11 @@ public class AnnotatedRecord extends MutationRecord{
     protected String codonChange;
     protected String hotspot;
     protected String consequence;
-    
-    static {                       
-        HEADER.add("HGVSc");
-        HEADER.add("HGVSp");
-        HEADER.add("HGVSp_Short");
-        HEADER.add("Transcript_ID");
-        HEADER.add("RefSeq");
-        HEADER.add("Protein_position");
-        HEADER.add("Codons");        
-        HEADER.add("Hotspot");
-        HEADER.add(HEADER.indexOf("Variant_Classification"), "Consequence");
+
+    public AnnotatedRecord() {
+        addAnnotatedFieldsToHeader();
     }
 
-    public AnnotatedRecord() {}
-    
     public AnnotatedRecord(String hugoSymbol,
         String entrezGeneId,
         String center,
@@ -113,7 +103,7 @@ public class AnnotatedRecord extends MutationRecord{
         String hotspot,
         String consequence,
         Map<String, String> additionalProperties
-    ) {        
+    ) {
         super(hugoSymbol,
             entrezGeneId,
             center,
@@ -163,77 +153,90 @@ public class AnnotatedRecord extends MutationRecord{
         this.codonChange = codonChange;
         this.hotspot = hotspot;
         this.consequence = consequence;
-    }  
+        addAnnotatedFieldsToHeader();
+    }
 
     public String getHGVSc() {
         return this.hgvsc;
     }
-    
+
     public void setHGVSc(String hgvsc) {
         this.hgvsc = hgvsc;
-    }   
-    
+    }
+
     public String getHGVSp() {
         return this.hgvsp;
     }
-    
+
     public void setHGVSp(String hgvsp) {
         this.hgvsp = hgvsp;
-    } 
+    }
 
     public String getHGVSp_Short() {
         return this.hgvspShort;
     }
-    
+
     public void setHGVSp_Short(String hgvspShort) {
         this.hgvspShort = hgvspShort;
-    }    
-    
+    }
+
     public String getTranscript_ID() {
         return this.transcriptId;
     }
-    
+
     public void setTranscript_ID(String transcriptId) {
         this.transcriptId = transcriptId;
-    }     
-    
+    }
+
     public String getRefSeq() {
         return this.refSeq;
     }
-    
+
     public void setRefSeq(String refSeq) {
         this.refSeq = refSeq;
-    }    
-    
+    }
+
     public String getProtein_position() {
         return this.proteinPosStart;
     }
-    
+
     public void setProtein_position(String proteinPosStart) {
         this.proteinPosStart = proteinPosStart;
     }
-    
+
     public String getCodons() {
         return this.codonChange;
     }
-    
+
     public void setCodons(String codonChange) {
         this.codonChange = codonChange;
     }
-    
+
     public String getHotspot() {
         return this.hotspot;
     }
-    
+
     public void setHotspot(String hotspot) {
         this.hotspot = hotspot;
     }
-    
+
     public String getConsequence() {
         return this.consequence;
     }
-    
+
     public void setConsquence(String consequence) {
         this.consequence = consequence;
+    }
+
+    private void addAnnotatedFieldsToHeader() {
+        header.add("HGVSc");
+        header.add("HGVSp");
+        header.add("HGVSp_Short");
+        header.add("Transcript_ID");
+        header.add("RefSeq");
+        header.add("Protein_position");
+        header.add("Codons");
+        header.add("Hotspot");
+        header.add(header.indexOf("Variant_Classification"), "Consequence");
     }
 }

--- a/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
+++ b/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
@@ -78,63 +78,23 @@ public class MutationRecord {
     protected String nRefCount;
     protected String nAltCount;
     protected Map<String, String> additionalProperties = new LinkedHashMap<>();
-    
-    protected static final List<String> HEADER;
-    
-    static {
-       HEADER = new ArrayList<>();
-        
-        HEADER.add("Hugo_Symbol");
-        HEADER.add("Entrez_Gene_Id");
-        HEADER.add("Center");
-        HEADER.add("NCBI_Build");
-        HEADER.add("Chromosome");
-        HEADER.add("Start_Position");
-        HEADER.add("End_Position");
-        HEADER.add("Strand");
-        HEADER.add("Variant_Classification");
-        HEADER.add("Variant_Type");
-        HEADER.add("Reference_Allele");
-        HEADER.add("Tumor_Seq_Allele1");
-        HEADER.add("Tumor_Seq_Allele2");
-        HEADER.add("dbSNP_RS");
-        HEADER.add("dbSNP_Val_Status");
-        HEADER.add("Tumor_Sample_Barcode");
-        HEADER.add("Matched_Norm_Sample_Barcode");
-        HEADER.add("Match_Norm_Seq_Allele1");
-        HEADER.add("Match_Norm_Seq_Allele2");
-        HEADER.add("Tumor_Validation_Allele1");
-        HEADER.add("Tumor_Validation_Allele2");
-        HEADER.add("Match_Norm_Validation_Allele1");
-        HEADER.add("Match_Norm_Validation_Allele2");
-        HEADER.add("Verification_Status");
-        HEADER.add("Validation_Status");
-        HEADER.add("Mutation_Status");
-        HEADER.add("Sequencing_Phase");
-        HEADER.add("Sequence_Source");
-        HEADER.add("Validation_Method");
-        HEADER.add("Score");
-        HEADER.add("BAM_File");
-        HEADER.add("Sequencer");
-        HEADER.add("t_ref_count");
-        HEADER.add("t_alt_count");
-        HEADER.add("n_ref_count");
-        HEADER.add("n_alt_count");       
-    }    
+    protected List<String> header = new ArrayList<>();
 
-    public MutationRecord() {}
-    
-    public MutationRecord(String hugoSymbol, String entrezGeneId, String center, String ncbiBuild, 
-            String chromosome, String startPosition, String endPosition, String strand, String variantClassification, 
+    public MutationRecord() {
+        initHeader();
+    }
+
+    public MutationRecord(String hugoSymbol, String entrezGeneId, String center, String ncbiBuild,
+            String chromosome, String startPosition, String endPosition, String strand, String variantClassification,
             String variantType, String referenceAllele, String tumorSeqAllele1, String tumorSeqAllele2, String dbSnpRs,
-            String dbSnpValStatus, String tumorSampleBarcode, String matchedNormSampleBarcode, 
+            String dbSnpValStatus, String tumorSampleBarcode, String matchedNormSampleBarcode,
             String matchedNormSeqAllele1, String matchedNormSeqAllele2, String tumorValidationAllele1,
             String tumorValidationAllele2, String matchNormValidationAllele1, String matchNormValidationAllele2,
             String verificationStatus, String validationStatus, String mutationStatus, String sequencingPhase,
             String sequencingSource, String validationMethod, String score, String bamFile, String sequencer,
             String tumorSampleUUID, String matchedNormSampleUUID, String tRefCount, String tAltCount,
             String nRefCount, String nAltCount, Map<String, String> additionalProperties) {
-        
+
         this.hugoSymbol = hugoSymbol;
         this.entrezGeneId = entrezGeneId;
         this.center = center;
@@ -172,18 +132,19 @@ public class MutationRecord {
         this.tRefCount = tRefCount;
         this.tAltCount = tAltCount;
         this.nRefCount = nRefCount;
-        this.nAltCount = nAltCount;    
+        this.nAltCount = nAltCount;
         this.additionalProperties = additionalProperties;
+        initHeader();
     }
-    
+
     public String getHugo_Symbol() {
         return this.hugoSymbol == null ? "" : this.hugoSymbol;
     }
-    
+
     public void setHugo_Symbol(String hugoSymbol) {
         this.hugoSymbol = hugoSymbol;
     }
-    
+
     public String getEntrez_Gene_Id() {
         return this.entrezGeneId == null ? "" : this.entrezGeneId;
     }
@@ -191,139 +152,139 @@ public class MutationRecord {
     public void setEntrez_Gene_Id(String entrezGeneId) {
         this.entrezGeneId = entrezGeneId;
     }
-    
+
     public String getCenter() {
         return this.center == null ? "" : this.center;
     }
-    
+
     public void setCenter(String center) {
         this.center = center;
     }
-    
+
     public String getNCBI_Build() {
         return this.ncbiBuild == null ? "" : this.ncbiBuild;
     }
-    
+
     public void setNCBI_Build(String ncbiBuild) {
         this.ncbiBuild = ncbiBuild;
     }
-    
+
     public String getChromosome() {
         return this.chromosome == null ? "" : this.chromosome;
     }
-    
+
     public void setChromosome(String chromosome) {
         this.chromosome = chromosome;
     }
-    
+
     public String getStart_Position() {
         return this.startPosition == null ? "" : this.startPosition;
     }
-    
+
     public void setStart_Position(String startPosition) {
         this.startPosition = startPosition;
     }
-    
-    public String getEnd_Position() {      
+
+    public String getEnd_Position() {
         return this.endPosition == null ? "" : this.endPosition;
     }
-    
+
     public void setEnd_Position(String endPosition) {
         this.endPosition = endPosition;
     }
-     
+
     public String getStrand() {
         return this.strand == null ? "" : this.strand;
     }
-    
+
     public void setStrand(String strand) {
         this.strand = strand;
     }
-    
+
     public String getVariant_Classification() {
         return this.variantClassification == null ? "" : this.variantClassification;
     }
-    
+
     public void setVariant_Classification(String variantClassification) {
         this.variantClassification = variantClassification;
     }
-    
+
     public String getVariant_Type() {
         return this.variantType == null ? "" : this.variantType;
     }
-    
+
     public void setVariant_Type(String variantType) {
         this.variantType = variantType;
     }
-    
+
     public String getReference_Allele() {
         return this.referenceAllele == null ? "" : this.referenceAllele;
     }
-    
+
     public void setReference_Allele(String referenceAllele) {
         this.referenceAllele = referenceAllele;
     }
-    
+
     public String getTumor_Seq_Allele1() {
         return this.tumorSeqAllele1 == null ? "" : this.tumorSeqAllele1;
     }
-    
+
     public void setTumor_Seq_Allele1(String tumorSeqAllele1) {
         this.tumorSeqAllele1 = tumorSeqAllele1;
     }
-    
+
     public String getTumor_Seq_Allele2() {
         return this.tumorSeqAllele2 == null ? "" : this.tumorSeqAllele2;
     }
-    
+
     public void setTumor_Seq_Allele2(String tumorSeqAllele2) {
         this.tumorSeqAllele2 = tumorSeqAllele2;
     }
-    
+
     public String getdbSNP_RS() {
         return this.dbSnpRs == null ? "" : this.dbSnpRs;
     }
-    
+
     public void setdbSNP_RS(String dbSnpRs) {
         this.dbSnpRs = dbSnpRs;
     }
-    
+
     public String getdbSNP_Val_Status() {
         return this.dbSnpValStatus == null ? "" : this.dbSnpValStatus;
     }
-    
+
     public void setdbSNP_Val_Status(String dbSnpValStatus) {
         this.dbSnpValStatus = dbSnpValStatus;
     }
-    
+
     public String getTumor_Sample_Barcode() {
         return this.tumorSampleBarcode == null ? "" : this.tumorSampleBarcode;
     }
-    
+
     public void setTumor_Sample_Barcode(String tumorSampleBarcode) {
         this.tumorSampleBarcode = tumorSampleBarcode;
     }
-    
+
     public String getMatched_Norm_Sample_Barcode() {
         return this.matchedNormSampleBarcode == null ? "" : this.matchedNormSampleBarcode;
     }
-    
+
     public void setMatched_Norm_Sample_Barcode(String matchedNormSampleBarcode) {
         this.matchedNormSampleBarcode = matchedNormSampleBarcode;
     }
-    
+
     public String getMatch_Norm_Seq_Allele1() {
         return this.matchNormValidationAllele1 == null ? "" : this.matchedNormSeqAllele1;
     }
-    
+
     public void setMatch_Norm_Seq_Allele1(String matchedNormSeqAllele1) {
         this.matchedNormSeqAllele1 = matchedNormSeqAllele1;
     }
-    
+
     public String getMatch_Norm_Seq_Allele2() {
         return this.matchNormValidationAllele2 == null ? "" : this.matchedNormSeqAllele2;
     }
-    
+
     public void setMatch_Norm_Seq_Allele2(String matchedNormSeqAllele2) {
         this.matchedNormSeqAllele2 = matchedNormSeqAllele2;
     }
@@ -331,7 +292,7 @@ public class MutationRecord {
     public String getTumor_Validation_Allele1() {
         return this.tumorValidationAllele1 == null ? "" : this.tumorValidationAllele1;
     }
-    
+
     public void setTumor_Validation_Allele1(String tumorValidationAllele1) {
         this.tumorValidationAllele1 = tumorValidationAllele1;
     }
@@ -339,172 +300,211 @@ public class MutationRecord {
     public String getTumor_Validation_Allele2() {
         return this.tumorValidationAllele2 == null ? "" : this.tumorValidationAllele2;
     }
-    
+
      public void setTumor_Validation_Allele2(String tumorValidationAllele2) {
         this.tumorValidationAllele2 = tumorValidationAllele2;
     }
-    
+
     public String getMatch_Norm_Validation_Allele1() {
         return this.matchNormValidationAllele1 == null ? "" : this.matchNormValidationAllele1;
     }
-    
+
     public void setMatch_Norm_Validation_Allele1(String matchNormValidationAllele1) {
         this.matchNormValidationAllele1 = matchNormValidationAllele1;
     }
-    
+
     public String getMatch_Norm_Validation_Allele2() {
         return this.matchNormValidationAllele2 == null ? "" : this.matchNormValidationAllele2;
     }
-    
+
     public void setMatch_Norm_Validation_Allele2(String matchNormValidationAllele2) {
         this.matchNormValidationAllele2 = matchNormValidationAllele2;
     }
-    
+
     public String getVerification_Status() {
         return this.verificationStatus == null ? "" : this.verificationStatus;
     }
-    
+
     public void setVerification_Status(String verificationStatus) {
         this.verificationStatus = verificationStatus;
     }
-    
+
     public String getValidation_Status() {
         return this.validationStatus == null ? "" : this.validationStatus;
     }
-    
+
     public void setValidation_Status(String validationStatus) {
         this.validationStatus = validationStatus;
     }
-    
+
     public String getMutation_Status() {
         return this.mutationStatus == null ? "" : this.mutationStatus;
     }
-    
+
     public void setMutation_Status(String mutationStatus) {
         this.mutationStatus = mutationStatus;
     }
-    
+
     public String getSequencing_Phase() {
         return this.sequencingPhase == null ? "" : this.sequencingPhase;
     }
-    
+
     public void setSequencing_Phase(String sequencingPhase) {
         this.sequencingPhase = sequencingPhase;
     }
-    
+
     public String getSequence_Source() {
         return this.sequencingSource == null ? "" : this.sequencingSource;
     }
-    
+
     public void setSequence_Source(String sequencingSource) {
         this.sequencingSource = sequencingSource;
     }
-    
+
     public String getValidation_Method() {
         return this.validationMethod == null ? "" : validationMethod;
     }
- 
+
     public void setValidation_Method(String validationMethod) {
         this.validationMethod = validationMethod;
     }
-    
+
     public String getScore() {
         return this.score == null ? "" : this.score;
     }
-    
+
     public void setScore(String score) {
         this.score = score;
     }
-    
+
     public String getBAM_File() {
         return this.bamFile == null ? "" : this.bamFile;
     }
-    
+
     public void setBAM_File(String bamFile) {
         this.bamFile = bamFile;
     }
-    
+
     public String getSequencer() {
         return this.sequencer == null ? "" : this.sequencer;
     }
-    
+
     public void setSequencer(String sequencer) {
         this.sequencer = sequencer;
     }
-    
+
     public String getTumor_Sample_UUID() {
         return this.tumorSampleUUID == null ? "" : this.tumorSampleUUID;
     }
-    
+
     public void setTumor_Sample_UUID(String tumorSampleUUID) {
         this.tumorSampleUUID = tumorSampleUUID;
     }
-    
+
     public String getMatched_Norm_Sample_UUID() {
         return this.matchedNormSampleUUID == null ? "" : this.matchedNormSampleUUID;
     }
-    
+
     public void setMatched_Norm_Sample_UUID(String matchedNormSampleUUID) {
         this.matchedNormSampleUUID = matchedNormSampleUUID;
     }
-    
+
     public String gett_ref_count() {
         return this.tRefCount == null ? "" : this.tRefCount;
     }
-    
+
     public void sett_ref_count(String tRefCount) {
         this.tRefCount = tRefCount;
     }
-    
+
     public String gett_alt_count() {
         return this.tAltCount == null ? "" : this.tAltCount;
     }
-    
+
     public void sett_alt_count(String tAltCount) {
         this.tAltCount = tAltCount;
     }
-    
+
     public String getn_ref_count() {
         return this.nRefCount == null ? "" : this.nRefCount;
     }
-    
+
     public void setn_ref_count(String nRefCount) {
         this.nRefCount = nRefCount;
     }
-    
+
     public String getn_alt_count() {
         return this.nAltCount == null ? "" : this.nAltCount;
     }
-    
+
     public void setn_alt_count(String nAltCount) {
         this.nAltCount = nAltCount;
-    } 
-    
+    }
+
     public void addAdditionalProperty(String property, String value) {
         this.additionalProperties.put(property, value);
     }
-    
+
     public Map<String, String> getAdditionalProperties() {
         return this.additionalProperties;
     }
-    
+
     public void setAdditionalProperties(Map<String, String> additionalProperties) {
         this.additionalProperties = additionalProperties;
-    } 
-    
+    }
+
     public List<String> getHeaderWithAdditionalFields() {
         List<String> headerWithAdditionalFields = new ArrayList<>();
-        headerWithAdditionalFields.addAll(HEADER);
-        
+        headerWithAdditionalFields.addAll(header);
+
         for (String field : additionalProperties.keySet()) {
             if (!headerWithAdditionalFields.contains(field)) {
                 headerWithAdditionalFields.add(field);
             }
-        }                
+        }
         return headerWithAdditionalFields;
     }
-    
+
     public List<String> getHeader() {
-        return  HEADER;
+        return  header;
+    }
+
+    public void initHeader() {
+        header.add("Hugo_Symbol");
+        header.add("Entrez_Gene_Id");
+        header.add("Center");
+        header.add("NCBI_Build");
+        header.add("Chromosome");
+        header.add("Start_Position");
+        header.add("End_Position");
+        header.add("Strand");
+        header.add("Variant_Classification");
+        header.add("Variant_Type");
+        header.add("Reference_Allele");
+        header.add("Tumor_Seq_Allele1");
+        header.add("Tumor_Seq_Allele2");
+        header.add("dbSNP_RS");
+        header.add("dbSNP_Val_Status");
+        header.add("Tumor_Sample_Barcode");
+        header.add("Matched_Norm_Sample_Barcode");
+        header.add("Match_Norm_Seq_Allele1");
+        header.add("Match_Norm_Seq_Allele2");
+        header.add("Tumor_Validation_Allele1");
+        header.add("Tumor_Validation_Allele2");
+        header.add("Match_Norm_Validation_Allele1");
+        header.add("Match_Norm_Validation_Allele2");
+        header.add("Verification_Status");
+        header.add("Validation_Status");
+        header.add("Mutation_Status");
+        header.add("Sequencing_Phase");
+        header.add("Sequence_Source");
+        header.add("Validation_Method");
+        header.add("Score");
+        header.add("BAM_File");
+        header.add("Sequencer");
+        header.add("t_ref_count");
+        header.add("t_alt_count");
+        header.add("n_ref_count");
+        header.add("n_alt_count");
     }
 }


### PR DESCRIPTION
Static header causes an issue where after an annotated record was instantiated, all mutation records will also have extra fields in the header they shouldn't have. Use initHeader design instead, and add items to the header in the annotation record constructors.

@sheridancbio @angelicaochoa 