### PR TITLE
Annotation Pipeline annotated file header bug fix

### DIFF
--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
@@ -55,7 +55,7 @@ public class AnnotationPipeline
             .addOption("f", "filename", true, "Mutation filename")
             .addOption("o", "outputFilename", true, "Output filename (including path)")
             .addOption("i", "isoformOverride", true, "Isoform Overrides (mskcc or uniprot)")
-            .addOption("r", "replace-symbol", true, "Replace gene symbols with what is provided by annotator" );
+            .addOption("r", "replace-symbol", false, "Replace gene symbols with what is provided by annotator" );
 
         return gnuOptions;
     }

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
@@ -124,7 +124,7 @@ public class MutationRecordReader  implements ItemStreamReader<AnnotatedRecord>{
                 LOG.info(message);
             }            
             annotatedRecords.add(annotatedRecord);
-            header.addAll(record.getHeaderWithAdditionalFields());
+            header.addAll(annotatedRecord.getHeaderWithAdditionalFields());
         }
         // log number of records that failed annotations
         LOG.info("Total records that failed annotation: " + failedAnnotations);


### PR DESCRIPTION
Changes in the way that the annotated file header were not propagated to the annotation pipeline.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>