### PR TITLE
Set Default for consequence effect priority and toLowerCase

### DIFF
--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -696,7 +696,7 @@ public class GenomeNexusImpl implements Annotator {
         for (String consequence : consequences) {
             if (effectPriority.getOrDefault(consequence.toLowerCase(), Integer.MAX_VALUE) < highestPriority) {
                 highestPriorityConsequence = consequence;
-                highestPriority = effectPriority.get(consequence);
+                highestPriority = effectPriority.getOrDefault(consequence.toLowerCase(), Integer.MAX_VALUE);
             }
         }
         return highestPriorityConsequence;


### PR DESCRIPTION
Prevents an NPE if a consequence does not exist in our mapping by defaulting to the highest Integer value.

@angelicaochoa could you quickly take a look?