### PR TITLE
Use highest priority consequence to pick out of canonical transcripts

### DIFF
--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -654,16 +654,27 @@ public class GenomeNexusImpl implements Annotator {
     }
 
     private TranscriptConsequence transcriptWithMostSevereConsequence(List<TranscriptConsequence> transcripts, String mostSevereConsequence) {
+        Integer highestPriority = Integer.MAX_VALUE;
+        TranscriptConsequence highestPriorityTranscript = null;
         for (TranscriptConsequence transcript : transcripts) {
             List<String> consequenceTerms = transcript.getConsequenceTerms();
             for (String consequenceTerm : consequenceTerms) {
+                if (effectPriority.getOrDefault(consequenceTerm.toLowerCase(), Integer.MAX_VALUE) < highestPriority) {
+                    highestPriorityTranscript = transcript;
+                    highestPriority = effectPriority.getOrDefault(consequenceTerm.toLowerCase(), Integer.MAX_VALUE);
+                }
                 if (consequenceTerm.trim().equals(mostSevereConsequence)) {
                     return transcript;
                 }
             }
         }
 
-        // no match, return the first one
+        // no match, pick one with the highest priority
+        if (highestPriorityTranscript != null) {
+            return highestPriorityTranscript;
+        }
+        
+        // if for whatever reason that is null, just return the first one.
         if (transcripts.size() > 0) {
             return transcripts.get(0);
         }


### PR DESCRIPTION
We should be picking highest priority consequence out of the canonicals, even if it isn't the most severe.

Signed-off-by: zheins <zackheins@gmail.com>