### PR TITLE
Add performance benchmark for CHOL TCGA GDC (GRCh38)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,20 +120,21 @@ jobs:
               TOTAL_VARIANTS=$(tail -n +2 test/data/chol_tcga_gdc_data_mutations.txt | grep -cv '^#' || echo "")
             fi
             RUNTIME=$(grep -oP '(?<=RUNTIME: )\d+' "$LOG" || echo "")
+            ANNOTATION_TIME=$(grep -oP '(?<=ANNOTATION_TIME: )\d+' "$LOG" || echo "")
             AVG_RESPONSE=$(grep -oP '(?<=Average Response Time:  )[\d.]+' "$LOG" || echo "")
             TOTAL_RESPONSE=$(grep -oP '(?<=Total Response Time:  )\d+' "$LOG" || echo "")
             AMBIGUOUS=$(grep -oP '(?<=ambiguous SNP and INDEL allele changes:  )\d+' "$LOG" || echo "")
             FAILED=$(grep -oP '\d+(?= total failed annotations)' "$LOG" || echo "0")
 
-            if [ -n "$TOTAL_VARIANTS" ] && [ -n "$RUNTIME" ] && [ "$RUNTIME" -gt 0 ]; then
-              VARIANTS_PER_SEC=$(awk "BEGIN {printf \"%.1f\", $TOTAL_VARIANTS / $RUNTIME}")
+            if [ -n "$TOTAL_VARIANTS" ] && [ -n "$ANNOTATION_TIME" ] && [ "$ANNOTATION_TIME" -gt 0 ]; then
+              VARIANTS_PER_SEC=$(awk "BEGIN {printf \"%.1f\", $TOTAL_VARIANTS / $ANNOTATION_TIME}")
             else
               VARIANTS_PER_SEC=""
             fi
 
             CSV=test/data/benchmark_results.csv
-            echo "dataset,server,total_variants,runtime_secs,variants_per_sec,avg_response_secs,total_response_secs,ambiguous_records,failed_annotations" > "$CSV"
-            echo "chol_tcga_gdc,grch38.genomenexus.org,$TOTAL_VARIANTS,$RUNTIME,$VARIANTS_PER_SEC,$AVG_RESPONSE,$TOTAL_RESPONSE,$AMBIGUOUS,$FAILED" >> "$CSV"
+            echo "dataset,server,total_variants,runtime_secs,annotation_time_secs,variants_per_sec,avg_response_secs,total_response_secs,ambiguous_records,failed_annotations" > "$CSV"
+            echo "chol_tcga_gdc,grch38.genomenexus.org,$TOTAL_VARIANTS,$RUNTIME,$ANNOTATION_TIME,$VARIANTS_PER_SEC,$AVG_RESPONSE,$TOTAL_RESPONSE,$AMBIGUOUS,$FAILED" >> "$CSV"
 
             echo ""
             echo "=== Benchmark Results ==="

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,42 @@ jobs:
           name: "check if nucleotide_context provides Ref_Tri and Var_Tri columnsj"
           command: 'java -Dgenomenexus.enrichment_fields=annotation_summary,nucleotide_context -jar annotationPipeline/target/annotationPipeline-*.jar --filename test/data/data_mutations_extended_100.in.txt  --output-filename test/data/data_mutations_extended_100.out.uniprot.nucleotide_context.txt --isoform-override uniprot && git diff -G "^[^#]" --exit-code  test/data/data_mutations_extended_100.out.uniprot.nucleotide_context.txt || (echo simple MAF uniprot output changed  test/data/data_mutations_extended_100.out.uniprot.nucleotide_context.txt)'
 
+      - run:
+          name: "performance benchmark: annotate CHOL TCGA GDC (~3764 variants) against grch38.genomenexus.org"
+          command: |
+            java -Dgenomenexus.base=https://grch38.genomenexus.org \
+              -jar annotationPipeline/target/annotationPipeline-*.jar \
+              --filename test/data/chol_tcga_gdc_data_mutations.txt \
+              --output-filename test/data/chol_tcga_gdc_data_mutations.out.mskcc.txt \
+              --isoform-override mskcc 2>&1 | tee test/data/benchmark.log
+
+            # Parse stats into CSV
+            LOG=test/data/benchmark.log
+            # "records to annotate" is a log4j message that may not appear; fall back to counting input lines
+            TOTAL_VARIANTS=$(grep -oP '\d+(?= records to annotate)' "$LOG" || echo "")
+            if [ -z "$TOTAL_VARIANTS" ]; then
+              TOTAL_VARIANTS=$(tail -n +2 test/data/chol_tcga_gdc_data_mutations.txt | grep -cv '^#' || echo "")
+            fi
+            RUNTIME=$(grep -oP '(?<=RUNTIME: )\d+' "$LOG" || echo "")
+            AVG_RESPONSE=$(grep -oP '(?<=Average Response Time:  )[\d.]+' "$LOG" || echo "")
+            TOTAL_RESPONSE=$(grep -oP '(?<=Total Response Time:  )\d+' "$LOG" || echo "")
+            AMBIGUOUS=$(grep -oP '(?<=ambiguous SNP and INDEL allele changes:  )\d+' "$LOG" || echo "")
+            FAILED=$(grep -oP '\d+(?= total failed annotations)' "$LOG" || echo "0")
+
+            if [ -n "$TOTAL_VARIANTS" ] && [ -n "$RUNTIME" ] && [ "$RUNTIME" -gt 0 ]; then
+              VARIANTS_PER_SEC=$(awk "BEGIN {printf \"%.1f\", $TOTAL_VARIANTS / $RUNTIME}")
+            else
+              VARIANTS_PER_SEC=""
+            fi
+
+            CSV=test/data/benchmark_results.csv
+            echo "dataset,server,total_variants,runtime_secs,variants_per_sec,avg_response_secs,total_response_secs,ambiguous_records,failed_annotations" > "$CSV"
+            echo "chol_tcga_gdc,grch38.genomenexus.org,$TOTAL_VARIANTS,$RUNTIME,$VARIANTS_PER_SEC,$AVG_RESPONSE,$TOTAL_RESPONSE,$AMBIGUOUS,$FAILED" >> "$CSV"
+
+            echo ""
+            echo "=== Benchmark Results ==="
+            cat "$CSV"
+
       - store_artifacts:
           path: test/data
           destination: /test-data-output

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
@@ -88,7 +88,9 @@ public class AnnotationPipeline {
         addJobParameterIfValueIsNotNull(jobParametersBuilder, "addOriginalGenomicLocation", String.valueOf(addOriginalGenomicLocation));
         addJobParameterIfValueIsNotNull(jobParametersBuilder, "noteColumn", String.valueOf(noteColumn));
         JobParameters jobParameters = jobParametersBuilder.toJobParameters();
+        Instant annotationStart = Instant.now();
         JobExecution jobExecution = jobLauncher.run(annotationJob, jobParameters);
+        System.out.println(" ANNOTATION_TIME: " + Duration.between(annotationStart, Instant.now()).getSeconds() + " secs.");
         if (!jobExecution.getExitStatus().equals(ExitStatus.COMPLETED)) {
             System.exit(2);
         }

--- a/test/scripts/sync_tcga_data.sh
+++ b/test/scripts/sync_tcga_data.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Download TCGA test data from cBioPortal datahub (Git LFS media URL)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_DIR="$SCRIPT_DIR/../data"
+
+DATAHUB_BASE="https://media.githubusercontent.com/media/cBioPortal/datahub/master/crdc/gdc"
+
+# CHOL TCGA GDC (~3764 variants, GRCh38)
+echo "Downloading chol_tcga_gdc data_mutations.txt..."
+curl -sL "$DATAHUB_BASE/chol_tcga_gdc/data_mutations.txt" \
+    -o "$DATA_DIR/chol_tcga_gdc_data_mutations.txt"
+echo "Downloaded: $(wc -l < "$DATA_DIR/chol_tcga_gdc_data_mutations.txt") lines"


### PR DESCRIPTION
## Summary
- Add a CI step that annotates ~3764 GRCh38 variants from the CHOL TCGA GDC dataset against `grch38.genomenexus.org`
- Informational only (no `git diff --exit-code`) — prints RUNTIME and annotation summary stats
- Report separate `ANNOTATION_TIME` (pure annotation, excluding Spring Boot startup) alongside `RUNTIME`
- Benchmark CSV includes both timings; `variants_per_sec` is computed from `ANNOTATION_TIME` for accurate throughput
- Include `test/scripts/sync_tcga_data.sh` to re-download/update the input file from cBioPortal/datahub

## Test plan
- [x] CI runs the new performance benchmark step successfully
- [x] RUNTIME and ANNOTATION_TIME are both printed in CI output
- [x] `benchmark_results.csv` includes `runtime_secs`, `annotation_time_secs`, and `variants_per_sec` columns
- [x] Output file is available in stored artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)